### PR TITLE
Only set meta value when specified.

### DIFF
--- a/includes/class-wp-term-meta-ui.php
+++ b/includes/class-wp-term-meta-ui.php
@@ -465,7 +465,12 @@ class WP_Term_Meta_UI {
 		// Get the term being posted
 		$term_key = 'term-' . $this->meta_key;
 
-		// Bail if not updating meta_key
+		// Bail if not updating meta_key.
+		if ( ! isset( $_POST[ $term_key ] ) ) {
+			return;
+		}
+
+		// Set a default value if empty.
 		$meta = ! empty( $_POST[ $term_key ] )
 			? $_POST[ $term_key ]
 			: '';


### PR DESCRIPTION
Hi John-

I noticed that when updating terms via the “Quick Edit” interface, the `$_POST`
payload doesn’t include every meta field. So, the save routine is losing saved values when Quick Edit is used.

These term plugins are awesome. 
